### PR TITLE
Make text areas configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Once selection is made, the Snippet's text will be inserted in the field at the
 current position. If text is currently selected, the Snippet will replace the
 selection.
 
-Note that currently only the *Bug Note* field is configured to use Snippets.
+By default only the *Bug Note* field is configured to use Snippets.
 Other text fields (*Description*, *Steps To Reproduce* as well as *Additional
-Information*) can be setup to use Snippets with minimal configuration effort
-(see [this example](https://github.com/mantisbt-plugins/snippets/issues/3)).
-
+Information*) can be setup to use Snippets via configuration option `plugin_Snippets_textarea_names`
+where you can list names of fields you are interested in, i.e. `bugnote_text, steps_to_reproduce, body` (`body`
+refers to text area on *Send reminder* page).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,8 @@ current position. If text is currently selected, the Snippet will replace the
 selection.
 
 By default only the *Bug Note* field is configured to use Snippets.
-Other text fields (*Description*, *Steps To Reproduce* as well as *Additional
-Information*) can be setup to use Snippets via configuration option `plugin_Snippets_textarea_names`
-where you can list names of fields you are interested in, i.e. `bugnote_text, steps_to_reproduce, body` (`body`
-refers to text area on *Send reminder* page).
+Other *text* fields (*Description*, *Steps To Reproduce* as well as *Additional
+Information*) can be setup to use Snippets via configuration page `Manage > Global Snippets > Configuration`.
 
 ## Support
 

--- a/Snippets/Snippets.API.php
+++ b/Snippets/Snippets.API.php
@@ -37,9 +37,11 @@ function xmlhttprequest_plugin_snippets() {
 
 	# split names of textareas found in "plugin_Snippets_textarea_names" option and
 	#  make an array of "textarea[name='FIELD_NAME']" strings
-	$textareaSelectors = array_map(function($name) {
+	$textareaSelectors = array_map(
+		function($name) {
 			return "textarea[name='$name']";
-		}, preg_split("/[,;\s]+/", plugin_config_get("textarea_names", "bugnote_text"))
+		},
+		Snippet::get_configured_field_names()
 	);
 
 	$data = array(
@@ -58,6 +60,7 @@ function xmlhttprequest_plugin_snippets() {
 
 	plugin_pop_current();
 }
+
 
 /**
  * Object representing a saved block of text.
@@ -343,5 +346,26 @@ class Snippet {
 		}
 		return '';
 	}
-}
 
+	/**
+	 * Returns an array with names of form fields (text areas) where snippets should be
+	 * available for selection.
+	 */
+	public static function get_configured_field_names() {
+		return preg_split("/[,;\s]+/", plugin_config_get("textarea_names", "bugnote_text"));
+	}
+
+	/**
+	 * Returns an array of ('text area field name' => 'language resource identifier') pairs
+	 * that describe available (supported) text areas. Values will be passed to lang_get().
+	 */
+	public static function get_available_field_names() {
+		return array(
+			'bugnote_text' => 'bugnote',
+			'description' => 'description',
+			'steps_to_reproduce' => 'steps_to_reproduce',
+			'additional_information' => 'additional_information',
+			'body' => 'reminder'
+		);
+	}
+}

--- a/Snippets/Snippets.API.php
+++ b/Snippets/Snippets.API.php
@@ -35,13 +35,22 @@ function xmlhttprequest_plugin_snippets() {
 	$snippets = Snippet::load_by_type_user(0, $user_id, $use_global);
 	$snippets = Snippet::clean($snippets, "form", $bug_id);
 
-	$data = array(
-		"snippets" => SnippetsPlugin::$_version,
+	# split names of textareas found in "plugin_Snippets_textarea_names" option and
+	#  make an array of "textarea[name='FIELD_NAME']" strings
+	$textareaSelectors = array_map(function($name) {
+			return "textarea[name='$name']";
+		}, preg_split("/[,;\s]+/", plugin_config_get("textarea_names", "bugnote_text"))
 	);
 
-	# arrange the available snippets into the data array
+	$data = array(
+		"snippets" => SnippetsPlugin::$_version,
+		# return configured jQuery selectors for textareas in "selector" field
+		"selector" => implode(",", $textareaSelectors)
+	);
+
+	# arrange the available snippets into the data array and return it in "texts" field
 	foreach($snippets as $snippet) {
-		$data["bugnote_text"][$snippet->id] = $snippet;
+		$data["texts"][$snippet->id] = $snippet;
 	}
 
 	$json = json_encode($data);

--- a/Snippets/Snippets.php
+++ b/Snippets/Snippets.php
@@ -5,7 +5,7 @@
 # Licensed under the MIT license
 
 class SnippetsPlugin extends MantisPlugin {
-	public static $_version = "0.5";
+	public static $_version = "0.6";
 
 	public function register() {
 		$this->name = plugin_lang_get("name");
@@ -29,6 +29,7 @@ class SnippetsPlugin extends MantisPlugin {
 			"edit_global_threshold" => ADMINISTRATOR,
 			"use_global_threshold" => REPORTER,
 			"edit_own_threshold" => REPORTER,
+			"textarea_names" => "bugnote_text",
 		);
 	}
 
@@ -90,4 +91,3 @@ class SnippetsPlugin extends MantisPlugin {
 		);
 	}
 }
-

--- a/Snippets/files/snippets.js
+++ b/Snippets/files/snippets.js
@@ -42,18 +42,16 @@ jQuery(document).ready(function($) {
 		 * then insert select boxes into the DOM for each supported textarea.
 		 */
 		function SnippetsInit() {
-			var textareas = $("textarea[name='bugnote_text']");
-
 			function SnippetsUI(data) {
 				var textarrays = data;
 
-				textareas.each(function(index) {
+				$(data.selector).each(function(index) {
 						var textarea_name = $(this).attr("name");
 						var textarea = $(this);
 
 						try {
 
-						snippets = textarrays[textarea_name];
+						snippets = textarrays["texts"];
 						if (snippets != null) {
 							label = $("<label>" + SnippetsLang("label") + " </label>");
 
@@ -88,7 +86,8 @@ jQuery(document).ready(function($) {
 					});
 			}
 
-			if (textareas.length > 0) {
+			//if we have any textareas then fetch snippets
+			if ($("textarea").length > 0) {
 				var bug_id = 0;
 
 				$("form[name='bugnoteadd'] input[name='bug_id']").each(function() {

--- a/Snippets/lang/strings_english.txt
+++ b/Snippets/lang/strings_english.txt
@@ -54,3 +54,4 @@ $s_plugin_Snippets_pattern_help = '
 	</table>
 	';
 
+$s_plugin_Snippets_textarea_names = 'Use Snippets For';

--- a/Snippets/lang/strings_french.txt
+++ b/Snippets/lang/strings_french.txt
@@ -54,3 +54,4 @@ $s_plugin_Snippets_pattern_help = '
 	</table>
 	';
 
+$s_plugin_Snippets_textarea_names = 'Utiliser Bribes Pour';

--- a/Snippets/lang/strings_german.txt
+++ b/Snippets/lang/strings_german.txt
@@ -53,3 +53,5 @@ $s_plugin_Snippets_pattern_help = '
 	<tr><td><strong>%p</strong></td><td>Projektname</td></tr>
 	</table>
 	';
+
+$s_plugin_Snippets_textarea_names = 'Verwende Textbausteinen in';

--- a/Snippets/pages/config.php
+++ b/Snippets/pages/config.php
@@ -16,7 +16,7 @@ function maybe_set_option( $name, $value ) {
 maybe_set_option("edit_global_threshold", gpc_get_int("edit_global_threshold"));
 maybe_set_option("use_global_threshold", gpc_get_int("use_global_threshold"));
 maybe_set_option("edit_own_threshold", gpc_get_int("edit_own_threshold"));
+maybe_set_option("textarea_names", implode(",", gpc_get_string_array("textarea_names", '')));
 
 form_security_purge("plugin_Snippets_config");
 print_successful_redirect(plugin_page("config_page", true));
-

--- a/Snippets/pages/config_page.php
+++ b/Snippets/pages/config_page.php
@@ -34,6 +34,22 @@ print_manage_menu();
 <td><select name="edit_own_threshold"><?php print_enum_string_option_list( 'access_levels', plugin_config_get( 'edit_own_threshold' ) ) ?></select></td>
 </tr>
 
+<tr <?php echo helper_alternate_class() ?>>
+<td class="category"><?php echo plugin_lang_get( 'textarea_names' ) ?></td>
+<td>
+<?php
+  $configuredNames = Snippet::get_configured_field_names();
+  $availableNames = Snippet::get_available_field_names();
+
+  foreach( $availableNames as $name => $lang_get_param ) {
+    echo '<div><label><input type="checkbox" name="textarea_names[]" value="', $name, '" ';
+    check_checked( in_array($name, $configuredNames) );
+    echo '/>', lang_get( $lang_get_param ), "</label></div>\n";
+  }
+?>
+</td>
+</tr>
+
 <tr>
 <td class="center" colspan="2"><input type="submit" value="<?php echo plugin_lang_get("action_update") ?>"/></td>
 </tr>
@@ -43,4 +59,3 @@ print_manage_menu();
 
 <?php
 html_page_bottom();
-


### PR DESCRIPTION
Names of text areas which should have snippets available can now be configured via `plugin_Snippets_textarea_names` configuration option (default: "bugnote_text"), i.e. "bugnote_text, steps_to_reproduce". It makes including other fields easier than hard-coding each new field into code like proposed in [issue 3](https://github.com/mantisbt-plugins/snippets/issues/3)