### PR TITLE
Fix php error in config page

### DIFF
--- a/Snippets/pages/config.php
+++ b/Snippets/pages/config.php
@@ -16,7 +16,7 @@ function maybe_set_option( $name, $value ) {
 maybe_set_option("edit_global_threshold", gpc_get_int("edit_global_threshold"));
 maybe_set_option("use_global_threshold", gpc_get_int("use_global_threshold"));
 maybe_set_option("edit_own_threshold", gpc_get_int("edit_own_threshold"));
-maybe_set_option("textarea_names", implode(",", gpc_get_string_array("textarea_names", '')));
+maybe_set_option("textarea_names", implode(",", gpc_get_string_array("textarea_names")));
 
 form_security_purge("plugin_Snippets_config");
 print_successful_redirect(plugin_page("config_page", true));


### PR DESCRIPTION
Fix php error in config page

Don't pass a string as default value for an array to fix the following error:

'Argument 2 passed to gpc_get_string_array() must be of the type array, string given, called in root\to\base\plugins\Snippets\pages\config.php on line 19 and defined' in 'root\to\base\core\gpc_api.php' line 246