### PR TITLE
Add data directory with htaccess to allow web access

### DIFF
--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,0 +1,1 @@
+Require all granted


### PR DESCRIPTION
This creates the data/ directory with an .htaccess file that grants access permissions, resolving HTTP 403 errors when the directory is accessed via web requests.

Fixes the following errors:

```
[Sun Jun 08 08:36:57.038369 2025] [authz_core:error] [pid 15895] [client ...:42650] AH01630: client denied by server configuration: /mantisbt/plugins/Snippets/data, referer: https://mantis.example.com/view.php?id=1234
```