### PR TITLE
Set maximum width of snippet <select>

### DIFF
--- a/files/snippets.css
+++ b/files/snippets.css
@@ -4,6 +4,10 @@
  * Licensed under the MIT license
  */
 
+select.snippet {
+	max-width: 300px;
+}
+
 .snippetsTooltip {
 	position: fixed;
 	top: 0;

--- a/files/snippets.js
+++ b/files/snippets.js
@@ -40,7 +40,7 @@ jQuery(function($) {
 				if (Array.isArray(data.snippets) && data.snippets.length > 0) {
 					try {
 						// Create Snippets select
-						const select = $("<select></select>");
+						const select = $('<select class="snippet"></select>');
 
 						// Set the Tab index equal to the associated textareas
 						select.attr('tabindex', textarea.attr('tabindex'));


### PR DESCRIPTION
This allows for a select control that is narrower than the options list, when there snippets with a very long name.

Fixes #77

@Diablordk is this what you had in mind ? Please test and provide feedback.