### PR TITLE
Fix 403 Forbidden errors under strict Apache directory rules by routing AJAX via plugin.php

### DIFF
--- a/files/snippets.js
+++ b/files/snippets.js
@@ -11,9 +11,7 @@ jQuery(function($) {
 	 * @returns {string} REST API URL
 	 */
 	function rest_api(endpoint) {
-		// Using the full URL (through index.php) to avoid issues on sites
-		// where URL rewriting is not working (#31)
-		return "api/rest/index.php/plugins/Snippets/" + endpoint;
+		return "plugin.php?page=Snippets/" + endpoint;
 	}
 
 	/**
@@ -89,7 +87,7 @@ jQuery(function($) {
 
 			let url = rest_api('data');
 			if (bug_id > 0) {
-				url += "/" + bug_id;
+				url += "&bug_id=" + bug_id;
 			}
 
 			$.getJSON(url)

--- a/pages/data.php
+++ b/pages/data.php
@@ -1,0 +1,37 @@
+<?php
+# Copyright (c) 2010 - 2012  Amethyst Reese
+# Copyright (c) 2012 - 2021  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+# Licensed under the MIT license
+
+header('Content-Type: application/json');
+
+# Set the reference Bug Id for placeholders replacements
+$t_bug_id = gpc_get_int('bug_id', 0);
+
+# Load snippets available to the user
+$t_use_global = access_has_global_level(plugin_config_get('use_global_threshold'));
+$t_user_id = -1;
+if (access_has_global_level(plugin_config_get('edit_own_threshold'))) {
+	$t_user_id = auth_get_current_user_id();
+}
+$t_snippets = Snippet::load_by_type_user(Snippet::TYPE_STANDARD, $t_user_id, $t_use_global);
+$t_snippets = Snippet::clean($t_snippets, Snippet::TARGET_FORM, $t_bug_id);
+
+# Split names of textareas found in 'textarea_names' option, and
+# make an array of "textarea[name='FIELD_NAME']" strings
+$t_selectors = array_map(
+	function($name) {
+		return "textarea[name='$name']";
+	},
+	Snippet::get_configured_field_names()
+);
+
+$t_data = array(
+	# return configured jQuery selectors for textareas in "selector" field
+	'selector' => implode(',', $t_selectors),
+	'label' => plugin_lang_get('select_label'),
+	'default' => plugin_lang_get('select_default'),
+	'snippets' => array_values($t_snippets),
+);
+
+echo json_encode($t_data);

--- a/pages/help.php
+++ b/pages/help.php
@@ -1,0 +1,13 @@
+<?php
+# Copyright (c) 2010 - 2012  Amethyst Reese
+# Copyright (c) 2012 - 2021  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+# Licensed under the MIT license
+
+header('Content-Type: application/json');
+
+$t_help = array(
+	'title' => plugin_lang_get('pattern_title'),
+	'text'  => plugin_lang_get('pattern_help'),
+);
+
+echo json_encode($t_help);


### PR DESCRIPTION
Hello,

We encountered an issue with the Snippets plugin REST API routing on servers with strict directory access configurations (which is a common security hardening recommendation for MantisBT).

### The Problem
When the root `plugins/` directory has a `.htaccess` file configured with:

```apache
<IfModule mod_authz_core.c>
    Require all denied
</IfModule>
```

Any AJAX requests pointing to `api/rest/index.php/plugins/Snippets/data` or `api/rest/index.php/plugins/Snippets/help` return a 403 Forbidden status in Apache 2.4.

This happens because Apache evaluates security constraints on all path segments of the requested URL (including PATH_INFO), matching it against the physical `/plugins/` folder on disk and enforcing the `Require all denied` rule. On servers running security tools like Fail2ban/Wail2ban, these frequent 403 errors can lead to false-positive IP bans for legitimate users.

Proposed Solution / Workaround
Instead of routing public AJAX requests through the Slim REST API, they can be routed through the standard MantisBT plugin page wrapper (`plugin.php`).

By creating dedicated plugin pages:

1. `pages/data.php` (returning the JSON payload of `route_data`)
2. `pages/help.php` (returning the JSON payload of `route_help`)

And updating `snippets.js` to target:

* `plugin.php?page=Snippets/data&bug_id={id}`
* `plugin.php?page=Snippets/help`

The requests resolve directly to `/plugin.php` at the web root and completely bypass the directory authorization checks for the `/plugins/` subdirectory, preventing the 403 errors.

Would you consider introducing this fallback or switching the AJAX endpoints to standard plugin pages?

Thank you!